### PR TITLE
Undefined name: from PySide import QtGui

### DIFF
--- a/freecad/ship/shipGZ/Tools.py
+++ b/freecad/ship/shipGZ/Tools.py
@@ -27,6 +27,7 @@ import FreeCADGui as Gui
 from FreeCAD import Vector, Matrix, Placement
 import Part
 from FreeCAD import Units
+from PySide import QtGui
 from .. import Instance as ShipInstance
 from .. import WeightInstance
 from .. import TankInstance


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/FreeCAD/freecad.ship on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./setup.py:26:19: F821 undefined name '__version__'
      version=str(__version__),
                  ^
./freecad/ship/shipGZ/Tools.py:117:15: F821 undefined name 'QtGui'
        msg = QtGui.QApplication.translate(
              ^
./freecad/ship/shipGZ/Tools.py:196:23: F821 undefined name 'QtGui'
                msg = QtGui.QApplication.translate(
                      ^
./freecad/ship/shipGZ/Tools.py:204:23: F821 undefined name 'QtGui'
                msg = QtGui.QApplication.translate(
                      ^
./freecad/ship/shipGZ/Tools.py:229:23: F821 undefined name 'QtGui'
                msg = QtGui.QApplication.translate(
                      ^
./freecad/ship/shipGZ/Tools.py:237:23: F821 undefined name 'QtGui'
                msg = QtGui.QApplication.translate(
                      ^
./freecad/ship/shipGZ/Tools.py:249:23: F821 undefined name 'QtGui'
                msg = QtGui.QApplication.translate(
                      ^
./freecad/ship/shipGZ/Tools.py:274:23: F821 undefined name 'QtGui'
                msg = QtGui.QApplication.translate(
                      ^
./freecad/ship/shipGZ/Tools.py:282:23: F821 undefined name 'QtGui'
                msg = QtGui.QApplication.translate(
                      ^
./freecad/ship/shipGZ/Tools.py:294:23: F821 undefined name 'QtGui'
                msg = QtGui.QApplication.translate(
                      ^
10    F821 undefined name 'QtGui'
10
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree