### PR TITLE
Added the capytaine dependency to compute RAOs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
       <classname>ShipWorkbench</classname>
       <subdirectory>./</subdirectory>
       <icon>freecad/ship/resources/icons/Ship_Logo.svg</icon>
+      <depend>capytaine</depend>
       <depend>plot</depend>
       <tag>ship</tag>
       <tag>naval</tag>


### PR DESCRIPTION
capytaine dep was missing. I am also creating a PR to get it in ALLOWED_PYTHON_PACKAGES.txt