### PR TITLE
Use `App` alias when `FreeCAD` is not imported

### DIFF
--- a/freecad/ship/TankInstance.py
+++ b/freecad/ship/TankInstance.py
@@ -29,7 +29,7 @@ from FreeCAD import Base, Vector, Matrix, Placement, Rotation, Units
 import Part
 from .shipUtils import Paths, Math
 
-QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
+QT_TRANSLATE_NOOP = App.Qt.QT_TRANSLATE_NOOP
 
 
 def __linspace(val0, val1, n):

--- a/freecad/ship/resistanceAmadeo/TaskPanel.py
+++ b/freecad/ship/resistanceAmadeo/TaskPanel.py
@@ -33,7 +33,7 @@ from ..shipUtils import Locale
 from ..shipUtils import Selection
 from ..shipHydrostatics import Tools as Hydrostatics
 
-QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
+QT_TRANSLATE_NOOP = App.Qt.QT_TRANSLATE_NOOP
 
 
 class TaskPanel:

--- a/freecad/ship/resistanceHoltrop/TaskPanel.py
+++ b/freecad/ship/resistanceHoltrop/TaskPanel.py
@@ -33,7 +33,7 @@ from ..shipUtils import Locale
 from ..shipUtils import Selection
 from ..shipHydrostatics import Tools as Hydrostatics
 
-QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
+QT_TRANSLATE_NOOP = App.Qt.QT_TRANSLATE_NOOP
 
 
 class TaskPanel:

--- a/freecad/ship/shipAreasCurve/TaskPanel.py
+++ b/freecad/ship/shipAreasCurve/TaskPanel.py
@@ -33,7 +33,7 @@ from ..shipUtils import Locale
 from ..shipUtils import Selection
 from ..shipHydrostatics import Tools as Hydrostatics
 
-QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
+QT_TRANSLATE_NOOP = App.Qt.QT_TRANSLATE_NOOP
 
 
 class TaskPanel:

--- a/freecad/ship/shipHydrostatics/TaskPanel.py
+++ b/freecad/ship/shipHydrostatics/TaskPanel.py
@@ -34,7 +34,7 @@ from .. import Instance
 from ..shipUtils import Locale
 from ..shipUtils import Selection
 
-QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
+QT_TRANSLATE_NOOP = App.Qt.QT_TRANSLATE_NOOP
 
 
 class TaskPanel:


### PR DESCRIPTION
If FreeCAD is imported with App alias that can be used. Some files use the alias other don't.

Fix #67 