### PR TITLE
FreeCADWeb.Org ➞ FreeCAD.Org

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Welcome to FreeCAD-Ship!**
 
 ## Introduction
-FreeCAD-Ship is a free module for [FreeCAD](https://www.freecadweb.org) oriented to aid naval ship design by providing several tools commonly used in naval architecture, seakeeping and ship resistance.
+FreeCAD-Ship is a free module for [FreeCAD] oriented to aid naval ship design by providing several tools commonly used in naval architecture, seakeeping and ship resistance.
 
 ## Contents
 - [Features](#features)
@@ -100,20 +100,20 @@ The main transversal stability indicator, it is unsurprisingly required by the v
 
 ![RAOs](https://user-images.githubusercontent.com/1668392/140480149-88bbd2e4-a255-4f9d-893a-c325356d4263.png)
 
-With FreeCAD you can easily compute the Response Amplitude Operators (RAOs), considering the widely validated frequency domain code [Nemoh](https://lheea.ec-nantes.fr/logiciels-et-brevets/nemoh-presentation-192863.kjsp), and more specifially its Python wrapper [Capytaine](https://github.com/mancellin/capytaine).
+With FreeCAD you can easily compute the Response Amplitude Operators (RAOs), considering the widely validated frequency domain code [Nemoh], and more specifially its Python wrapper [Capytaine].
 
 ## Install
 
-This workbench is available for download via the FreeCAD [Addon Manager](https://wiki.freecadweb.org/Addon_manager)
+This workbench is available for download via the FreeCAD [Addon Manager][Addon-Manager]
 
 ## Usage
 
-Documentation for this workbench is available on the [Ship Workbench wiki page](https://wiki.freecadweb.org/Ship_Workbench)
+Documentation for this workbench is available on the [Ship Workbench wiki page][Wiki]
 
 ## Tutorials
 
-* Official Ship Workbench Tutorial [Part 1](https://wiki.freecadweb.org/FreeCAD-Ship_s60_tutorial)
-* Official Ship Workbench Tutorial [Part 2](https://wiki.freecadweb.org/FreeCAD-Ship_s60_tutorial_(II))
+* Official Ship Workbench Tutorial [Part 1][Tutorial-1]
+* Official Ship Workbench Tutorial [Part 2][Tutorial-2]
 
 ## Roadmap
 
@@ -130,14 +130,27 @@ There are many tools and features which will be implemented in this module:
 
 ## Discussion/Feedback
 
-Discuss bugs, feedback, thoughts etc.. on the official [FreeCAD forum thread](https://forum.freecadweb.org/viewtopic.php?f=8&t=60885)
+Discuss bugs, feedback, thoughts etc.. on the official [FreeCAD forum thread][Forum]
 
 ## Bugs/Enhancements
 
-Please open tickets in the [issue queue](https://github.com/FreeCAD/freecad.ship/issues)
+Please open tickets in the [issue queue][Issues]
 
 ## Authors
 
  - Jose Luis Cercós Pita <jlcercos@gmail.com>
  - Juan Manuel Muñoz-Godin (Ship resistance Holtrop and Amadeo tools)
  - Antonio Souto-Iglesias (Advisor of Juan Manuel Muñoz-Godin)
+
+
+<!----------------------------------------------------------------------------->
+
+[Addon-Manager]: https://github.com/FreeCAD/AddonManager
+[Tutorial-1]: https://wiki.freecad.org/FreeCAD-Ship_s60_tutorial
+[Tutorial-2]: https://wiki.freecad.org/FreeCAD-Ship_s60_tutorial_(II)
+[Capytaine]: https://github.com/mancellin/capytaine
+[FreeCAD]: https://freecad.org
+[Issues]: https://github.com/FreeCAD/freecad.ship/issues
+[Nemoh]: https://lheea.ec-nantes.fr/logiciels-et-brevets/nemoh-presentation-192863.kjsp
+[Forum]: https://forum.freecad.org/viewtopic.php?f=8&t=60885
+[Wiki]: https://wiki.freecad.org/Ship_Workbench

--- a/freecad/ship/Ship.py
+++ b/freecad/ship/Ship.py
@@ -23,7 +23,7 @@
 
 __title__="FreeCAD Ship module"
 __author__ = "Jose Luis Cercos-Pita"
-__url__ = "https://www.freecadweb.org"
+__url__ = "https://freecad.org"
 
 __doc__="The Ships module provide a set of tools to make some specific Naval" \
         " Architecture computations"

--- a/freecad/ship/resources/icons/Resistance_Amadeo.svg
+++ b/freecad/ship/resources/icons/Resistance_Amadeo.svg
@@ -426,7 +426,7 @@
        snapvisiblegridlinesonly="true" /></sodipodi:namedview><metadata
      id="metadata2990"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /><dc:creator><cc:Agent><dc:title>[Cercos-Pita J.L]</dc:title></cc:Agent></dc:creator><dc:title>Ship_AreaCurve</dc:title><dc:date>2014-02-18</dc:date><dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/Ship/resources/icons/Ship_AreaCurve.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor></cc:Work></rdf:RDF></metadata><g
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /><dc:creator><cc:Agent><dc:title>[Cercos-Pita J.L]</dc:title></cc:Agent></dc:creator><dc:title>Ship_AreaCurve</dc:title><dc:date>2014-02-18</dc:date><dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/Ship/resources/icons/Ship_AreaCurve.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor></cc:Work></rdf:RDF></metadata><g
      id="layer1"
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"><path

--- a/freecad/ship/resources/icons/Resistance_BlountFox.svg
+++ b/freecad/ship/resources/icons/Resistance_BlountFox.svg
@@ -451,7 +451,7 @@
        units="px" /></sodipodi:namedview><metadata
      id="metadata2990"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /><dc:creator><cc:Agent><dc:title>[Cercos-Pita J.L]</dc:title></cc:Agent></dc:creator><dc:title>Ship_AreaCurve</dc:title><dc:date>2014-02-18</dc:date><dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/Ship/resources/icons/Ship_AreaCurve.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor></cc:Work></rdf:RDF></metadata><g
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /><dc:creator><cc:Agent><dc:title>[Cercos-Pita J.L]</dc:title></cc:Agent></dc:creator><dc:title>Ship_AreaCurve</dc:title><dc:date>2014-02-18</dc:date><dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/Ship/resources/icons/Ship_AreaCurve.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor></cc:Work></rdf:RDF></metadata><g
      id="layer1"
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"><text

--- a/freecad/ship/resources/icons/Resistance_Holtrop.svg
+++ b/freecad/ship/resources/icons/Resistance_Holtrop.svg
@@ -426,7 +426,7 @@
        snapvisiblegridlinesonly="true" /></sodipodi:namedview><metadata
      id="metadata2990"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /><dc:creator><cc:Agent><dc:title>[Cercos-Pita J.L]</dc:title></cc:Agent></dc:creator><dc:title>Ship_AreaCurve</dc:title><dc:date>2014-02-18</dc:date><dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/Ship/resources/icons/Ship_AreaCurve.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor></cc:Work></rdf:RDF></metadata><g
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /><dc:creator><cc:Agent><dc:title>[Cercos-Pita J.L]</dc:title></cc:Agent></dc:creator><dc:title>Ship_AreaCurve</dc:title><dc:date>2014-02-18</dc:date><dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/Ship/resources/icons/Ship_AreaCurve.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor></cc:Work></rdf:RDF></metadata><g
      id="layer1"
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"><path

--- a/freecad/ship/resources/icons/Resistance_Savitsky.svg
+++ b/freecad/ship/resources/icons/Resistance_Savitsky.svg
@@ -451,7 +451,7 @@
        units="px" /></sodipodi:namedview><metadata
      id="metadata2990"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /><dc:creator><cc:Agent><dc:title>[Cercos-Pita J.L]</dc:title></cc:Agent></dc:creator><dc:title>Ship_AreaCurve</dc:title><dc:date>2014-02-18</dc:date><dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/Ship/resources/icons/Ship_AreaCurve.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor></cc:Work></rdf:RDF></metadata><g
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /><dc:creator><cc:Agent><dc:title>[Cercos-Pita J.L]</dc:title></cc:Agent></dc:creator><dc:title>Ship_AreaCurve</dc:title><dc:date>2014-02-18</dc:date><dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation><dc:publisher><cc:Agent><dc:title>FreeCAD</dc:title></cc:Agent></dc:publisher><dc:identifier>FreeCAD/src/Mod/Ship/resources/icons/Ship_AreaCurve.svg</dc:identifier><dc:rights><cc:Agent><dc:title>FreeCAD LGPL2+</dc:title></cc:Agent></dc:rights><cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license><dc:contributor><cc:Agent><dc:title>[agryson] Alexander Gryson</dc:title></cc:Agent></dc:contributor></cc:Work></rdf:RDF></metadata><g
      id="layer1"
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"><text

--- a/freecad/ship/resources/icons/Seakeeping_RAOs.svg
+++ b/freecad/ship/resources/icons/Seakeeping_RAOs.svg
@@ -354,7 +354,7 @@
           </cc:Agent>
         </dc:creator>
         <dc:date>2014-02-18</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Seakeeping_SetMesh.svg
+++ b/freecad/ship/resources/icons/Seakeeping_SetMesh.svg
@@ -345,7 +345,7 @@
         </dc:creator>
         <dc:title>Ship_Instance</dc:title>
         <dc:date>2014-02-18</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_AreaCurve.svg
+++ b/freecad/ship/resources/icons/Ship_AreaCurve.svg
@@ -103,7 +103,7 @@
         </dc:creator>
         <dc:title>Ship_AreaCurve</dc:title>
         <dc:date>2014-02-18</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_CapacityCurve.svg
+++ b/freecad/ship/resources/icons/Ship_CapacityCurve.svg
@@ -189,7 +189,7 @@
         </dc:creator>
         <dc:title>Ship_CapacityCurve</dc:title>
         <dc:date>2014-12-12</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_GZ.svg
+++ b/freecad/ship/resources/icons/Ship_GZ.svg
@@ -280,7 +280,7 @@
         </dc:creator>
         <dc:title>Ship_GZ</dc:title>
         <dc:date>2014-12-12</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_Hydrostatics.svg
+++ b/freecad/ship/resources/icons/Ship_Hydrostatics.svg
@@ -185,7 +185,7 @@
         </dc:creator>
         <dc:title>Ship_Hydrostatics</dc:title>
         <dc:date>2014-05-02</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_Instance.svg
+++ b/freecad/ship/resources/icons/Ship_Instance.svg
@@ -88,7 +88,7 @@
         </dc:creator>
         <dc:title>Ship_Instance</dc:title>
         <dc:date>2014-02-18</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_Load.svg
+++ b/freecad/ship/resources/icons/Ship_Load.svg
@@ -123,7 +123,7 @@
         </dc:creator>
         <dc:title>Ship_Load</dc:title>
         <dc:date>2014-02-18</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_LoadCondition.svg
+++ b/freecad/ship/resources/icons/Ship_LoadCondition.svg
@@ -139,7 +139,7 @@
         </dc:creator>
         <dc:title>Ship_LoadCondition</dc:title>
         <dc:date>2015-10-16</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_Logo.svg
+++ b/freecad/ship/resources/icons/Ship_Logo.svg
@@ -103,7 +103,7 @@
         </dc:creator>
         <dc:title>Ship_Logo</dc:title>
         <dc:date>2014-02-18</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_Module.svg
+++ b/freecad/ship/resources/icons/Ship_Module.svg
@@ -103,7 +103,7 @@
         </dc:creator>
         <dc:title>Ship_Module</dc:title>
         <dc:date>2014-02-18</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_SinkAndTrim.svg
+++ b/freecad/ship/resources/icons/Ship_SinkAndTrim.svg
@@ -1187,7 +1187,7 @@
           </cc:Agent>
         </dc:creator>
         <dc:date>2021-10-01</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_Tank.svg
+++ b/freecad/ship/resources/icons/Ship_Tank.svg
@@ -178,7 +178,7 @@
         </dc:creator>
         <dc:title>Ship_Tank</dc:title>
         <dc:date>2014-12-12</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_Weight.svg
+++ b/freecad/ship/resources/icons/Ship_Weight.svg
@@ -130,7 +130,7 @@
         </dc:creator>
         <dc:title>Ship_Weight</dc:title>
         <dc:date>2014-12-12</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/ship/resources/icons/Ship_Workbench.svg
+++ b/freecad/ship/resources/icons/Ship_Workbench.svg
@@ -103,7 +103,7 @@
         </dc:creator>
         <dc:title>ShipWorkbench</dc:title>
         <dc:date>2016-02-26</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>


### PR DESCRIPTION
This PR updates references to the  
old FreeCAD address to new one.

*FYI, domains don't mind the casing.*